### PR TITLE
Add standardisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+.DS_Store
+__pycache__/
+.ipynb_checkpoints/

--- a/Chemistry/standardise.ipynb
+++ b/Chemistry/standardise.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from standardise import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\hy929891\\OneDrive - GSK\\Documents\\Git\\JanssenProject\\Chemistry\\standardise.py:14: UserWarning: SMILES: nan is invalid\n",
+      "  warnings.warn('SMILES: {} is invalid'.format(smi))\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = pd.read_csv('../LINCS/input/janssen_compounds.csv')\n",
+    "df = standardise_dataframe(df)\n",
+    "df['SameInchikey'] = df['Compound InChIKey'] == df['std_inchi_key']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Compound Name</th>\n",
+       "      <th>Compound SMILES</th>\n",
+       "      <th>Compound InChIKey</th>\n",
+       "      <th>std_canonical_smiles</th>\n",
+       "      <th>std_inchi_key</th>\n",
+       "      <th>SameInchikey</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>82</th>\n",
+       "      <td>alimemazine</td>\n",
+       "      <td>CC(CN(C)C)CN1c2ccccc2Sc3ccccc13.CC(CN(C)C)CN1c...</td>\n",
+       "      <td>QVKSGMJGGSXIQM-UHFFFAOYSA-N</td>\n",
+       "      <td>CC(CN(C)C)CN1c2ccccc2Sc2ccccc21</td>\n",
+       "      <td>ZZHLYYDVIOPZBE-UHFFFAOYSA-N</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>330</th>\n",
+       "      <td>dihydroergotamine</td>\n",
+       "      <td>CN1C[C@@H](C[C@@H]2c3cccc4[nH]cc(C[C@@H]12)c34...</td>\n",
+       "      <td>VZRYIVGWIWBKGL-HRLAOBJBSA-N</td>\n",
+       "      <td>CN1C[C@H](C(=O)N[C@]2(C)O[C@@]3(O)[C@@H]4CCCN4...</td>\n",
+       "      <td>LUZRJRNZXALNLM-JGRZULCMSA-N</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>342</th>\n",
+       "      <td>DMSO</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         Compound Name                                    Compound SMILES  \\\n",
+       "82         alimemazine  CC(CN(C)C)CN1c2ccccc2Sc3ccccc13.CC(CN(C)C)CN1c...   \n",
+       "330  dihydroergotamine  CN1C[C@@H](C[C@@H]2c3cccc4[nH]cc(C[C@@H]12)c34...   \n",
+       "342               DMSO                                                NaN   \n",
+       "\n",
+       "               Compound InChIKey  \\\n",
+       "82   QVKSGMJGGSXIQM-UHFFFAOYSA-N   \n",
+       "330  VZRYIVGWIWBKGL-HRLAOBJBSA-N   \n",
+       "342                          NaN   \n",
+       "\n",
+       "                                  std_canonical_smiles  \\\n",
+       "82                     CC(CN(C)C)CN1c2ccccc2Sc2ccccc21   \n",
+       "330  CN1C[C@H](C(=O)N[C@]2(C)O[C@@]3(O)[C@@H]4CCCN4...   \n",
+       "342                                                      \n",
+       "\n",
+       "                   std_inchi_key  SameInchikey  \n",
+       "82   ZZHLYYDVIOPZBE-UHFFFAOYSA-N         False  \n",
+       "330  LUZRJRNZXALNLM-JGRZULCMSA-N         False  \n",
+       "342                                      False  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[~df['SameInchikey']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Chemistry/standardise.py
+++ b/Chemistry/standardise.py
@@ -1,0 +1,29 @@
+import warnings
+
+from rdkit import Chem
+import pandas as pd
+from chembl_structure_pipeline import standardizer
+import tqdm
+
+def read_standardise(smi) -> Chem.rdchem.Mol:
+    null_mol = Chem.MolFromSmiles('')
+    try:
+        m = Chem.MolFromSmiles(smi)
+        assert m is not None
+    except:
+        warnings.warn('SMILES: {} is invalid'.format(smi))
+        return null_mol
+    m = standardizer.standardize_mol(m)
+    m = standardizer.get_parent_mol(m)[0]
+    return m
+
+def standardise_dataframe(df):
+    mols = df['Compound SMILES'].apply(read_standardise)
+    df['std_canonical_smiles'] = mols.apply(Chem.MolToSmiles)
+    df['std_inchi_key'] = mols.apply(Chem.MolToInchiKey)
+    return df
+
+if __name__ == "__main__":
+    df = pd.read_csv('../LINCS/input/janssen_compounds.csv')
+    df = standardise_dataframe(df)
+    df.to_csv('janssen_compounds_std.csv')

--- a/Chemistry/standardise.py
+++ b/Chemistry/standardise.py
@@ -3,7 +3,6 @@ import warnings
 from rdkit import Chem
 import pandas as pd
 from chembl_structure_pipeline import standardizer
-import tqdm
 
 def read_standardise(smi) -> Chem.rdchem.Mol:
     null_mol = Chem.MolFromSmiles('')

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ TO DO:
 
 Please create your own branch and submit a pull request, any modifications to code can then be merged with the main branch after code review by other collaborators.
 https://dont-be-afraid-to-commit.readthedocs.io/en/latest/git/commandlinegit.html
+
+### Requirements
+
+[ChEMBL Structure Pipeline](https://github.com/chembl/ChEMBL_Structure_Pipeline) is required to standarise the molecules
+```
+conda install -c chembl chembl_structure_pipeline
+```


### PR DESCRIPTION
I added some code to standardise the SMILES of the compounds using ChEMBL's pipeline.
Only two compounds need to be noticed:
https://github.com/zealseeker/JanssenProject/blob/main/Chemistry/standardise.ipynb

alimemazine (https://pubchem.ncbi.nlm.nih.gov/compound/73707352) and dihydroergotamine (https://pubchem.ncbi.nlm.nih.gov/compound/10531)

Their SMILES in the document are “bipolymer”, which I think should be converted.